### PR TITLE
Fixed install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Setup
 -----
 
 ````
-pip install django-audit
+pip install django-audit-wazuh
 # or
-pip install git+https://github.com/peppelinux/django-audit.git
+pip install git+https://github.com/peppelinux/django-audit-wazuh.git
 ````
 
 Configuration


### PR DESCRIPTION
The current install instructions is incorrect. `pip install django-audit` will install a completely separate app unrelated to wazuh (is a django mongo app iirc)