### PR TITLE
Custom username field

### DIFF
--- a/auditing/__init__.py
+++ b/auditing/__init__.py
@@ -4,22 +4,27 @@ from django.contrib.auth.signals import (user_logged_in,
                                          user_login_failed,
                                          user_logged_out)
 from django.dispatch import receiver
+from django.conf import settings
+
 from . utils import get_request_info
 
+
 logger = logging.getLogger(__name__)
+
+USER_FIELD = getattr(settings, 'AUDIT_USERNAME_FIELD', 'username')
 
 
 @receiver(user_logged_in)
 def login_logger(sender, request, **kwargs):
     _msg = '"Django Login successful", "username": "{}", {}'
-    logger.info(_msg.format(request.POST['username'],
+    logger.info(_msg.format(request.POST[USER_FIELD],
                             get_request_info(request)))
 
 
 @receiver(user_login_failed)
 def login_failed_logger(sender, request, **kwargs):
     _msg = '"Django Login failed", "username": "{}", {}'
-    logger.warn(_msg.format(request.POST['username'],
+    logger.warn(_msg.format(request.POST[USER_FIELD],
                             get_request_info(request)))
 
 

--- a/auditing/middlewares.py
+++ b/auditing/middlewares.py
@@ -1,6 +1,7 @@
 import http
 import logging
 import re
+import json
 
 from django.conf import settings
 try:
@@ -49,7 +50,12 @@ class HttpHeadersLoggingMiddleware(MiddlewareMixin):
         response_headers = [(str(k), str(v)) for k, v in response.items()]
         for cookie in response.cookies.values():
             response_headers.append(('Set-Cookie', str(cookie.output(header=''))))
-        head_items = ['"{}": "{}"'.format(*hea) for hea in response_headers]
+
+        head_items = [
+            # Use json.dumps on value field below to ensure valid json
+            '"{}": "{}"'.format(k, json.dumps(v))
+            for k, v in response_headers
+        ]
         headers = ', '.join(head_items)
         _msg = '"Http Response", "method": "{}", "url": "{}", "status": "{}", {}'.format(request.method,
                                                                                          request.build_absolute_uri(),


### PR DESCRIPTION
Fixes a issue where the project might use a fieldname other than `username`, like `email` for example.