### PR TITLE
different username files

### DIFF
--- a/auditing/__init__.py
+++ b/auditing/__init__.py
@@ -22,9 +22,20 @@ def login_logger(sender, **kwargs):
 
 @receiver(user_login_failed)
 def login_failed_logger(sender, **kwargs):
-    USER_FIELD = getattr(settings, 'AUDIT_USERNAME_FIELD', 'username')
+
+    def get_username_in(credentials: dict):
+        """
+        Find the username in credentials dict based on list of valid username
+        keys.
+        """
+        USER_FIELDS = getattr(settings, 'AUDIT_USERNAME_FIELDS', ['username'])
+        for key in USER_FIELDS:
+            if key in credentials.keys():
+                return credentials[key]
+        raise KeyError("Valid username not found in credentials.")
+
     msg_data = get_request_info(kwargs['request'])
-    msg_data['username'] = kwargs['credentials'][USER_FIELD]
+    msg_data['username'] = get_username_in(kwargs['credentials'])
     logger.warn('"Django Login failed", {}'.format(
         format_log_message(msg_data)))
 

--- a/auditing/tests.py
+++ b/auditing/tests.py
@@ -159,21 +159,6 @@ class LoginLoggerReceiverTestCase(SignalsBaseTestCase):
         self.assertNotIn('"password1":', out)
         self.assertNotIn('"password2":', out)
 
-    @override_settings(AUDIT_USERNAME_FIELD='email')
-    def test_message_custom_user_field(self):
-        req = self._post(data={
-            "email": "user@example.com",
-            "password": "secret",
-        })
-
-        with self.assertLogs('auditing', level='INFO') as cm:
-            login_logger(
-                self.mock_sender,
-                user=MockUser(username='user@example.com'),
-                request=req)
-
-        self.assertIn('"username": "user@example.com"', cm.output[0])
-
 
 class LoginFailedLoggerReceiverTestCase(SignalsBaseTestCase):
 
@@ -313,21 +298,6 @@ class LogoutLoggerReceiverTestCase(SignalsBaseTestCase):
         self.assertNotIn('"password":', out)
         self.assertNotIn('"password1":', out)
         self.assertNotIn('"password2":', out)
-
-    @override_settings(AUDIT_USERNAME_FIELD='email')
-    def test_message_custom_user_field(self):
-        req = self._post(data={
-            "email": "user@example.com",
-            "password": "secret",
-        })
-
-        with self.assertLogs('auditing', level='INFO') as cm:
-            logout_logger(
-                self.mock_sender,
-                user=MockUser('user@example.com'),
-                request=req)
-
-        self.assertIn('"username": "user@example.com"', cm.output[0])
 
 
 class HTTPHeadersLoggingMiddlewareTestCase(TestCase):


### PR DESCRIPTION
Adds the ability to allow for different username fields on the login failed receiver.

See #17